### PR TITLE
Updates Ink and replace renamed components

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 		"babel-plugin-transform-react-jsx": "^6.24.1",
 		"eslint-config-xo-react": "^0.16.0",
 		"eslint-plugin-react": "^7.1.0",
-		"ink": "^0.4.1",
+		"ink": "^0.5.0",
 		"sinon": "^4.4.9",
 		"xo": "^0.20.3"
 	},

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const {h, Text, Component} = require('ink');
+const {h, Color, Component} = require('ink');
 const PropTypes = require('prop-types');
 const isEqual = require('lodash.isequal');
 const figures = require('figures');
@@ -14,9 +14,9 @@ const Indicator = ({isSelected}) => {
 	}
 
 	return (
-		<Text blue>
+		<Color blue>
 			{`${figures.pointer} `}
-		</Text>
+		</Color>
 	);
 };
 
@@ -25,9 +25,9 @@ Indicator.propTypes = {
 };
 
 const Item = ({isSelected, label}) => (
-	<Text blue={isSelected}>
+	<Color blue={isSelected}>
 		{label}
-	</Text>
+	</Color>
 );
 
 Item.propTypes = {

--- a/test.js
+++ b/test.js
@@ -1,4 +1,4 @@
-import {h, build, renderToString, Text} from 'ink';
+import {h, build, renderToString, Color} from 'ink';
 import {spy} from 'sinon';
 import figures from 'figures';
 import test from 'ava';
@@ -10,9 +10,9 @@ test('indicator', t => {
 
 test('indicator - selected', t => {
 	t.is(renderToString(<Indicator isSelected/>), renderToString((
-		<Text blue>
+		<Color blue>
 			{`${figures.pointer} `}
-		</Text>
+		</Color>
 	)));
 });
 
@@ -22,9 +22,9 @@ test('item', t => {
 
 test('item - selected', t => {
 	t.is(renderToString(<Item isSelected label="Test"/>), renderToString((
-		<Text blue>
+		<Color blue>
 			Test
-		</Text>
+		</Color>
 	)));
 });
 


### PR DESCRIPTION
Hello good people of ink-select-input,

`<Text/>` component has been deprecated in favour of a more decoupled solution.
See vadimdemedes/ink#65 and vadimdemedes/ink#82.