### PR TITLE
Add optional item key to be specified

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -49,7 +49,8 @@ render(<Demo/>);
 Type: `array`<br>
 Default: `[]`
 
-Items to display in a list. Each item must be an object and have `label` and `value` props.
+Items to display in a list. Each item must be an object and have `label` and `value` props, it may also optionally have a `key` prop.
+If no `key` prop is provided, `value` will be used as the item key.
 
 ### focus
 

--- a/src/SelectInput.js
+++ b/src/SelectInput.js
@@ -47,7 +47,7 @@ class SelectInput extends PureComponent {
 					const isSelected = index === selectedIndex;
 
 					return (
-						<Box key={item.value}>
+						<Box key={item.key || item.value}>
 							{React.createElement(indicatorComponent, {isSelected})}
 							{React.createElement(itemComponent, {...item, isSelected})}
 						</Box>


### PR DESCRIPTION
If the value of items are objects then currently the keys for all of them will end up being `[object Object]`. I can workaround this by setting a `toString` method on my value but it would be nice to (optionally) specify a key for each item.