### PR TITLE
Add initialIndex prop to control initially-selected item

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -58,6 +58,13 @@ Default: `true`
 
 Listen to user's input. Useful in case there are multiple input components at the same time and input must be "routed" to a specific component.
 
+### initialIndex
+
+Type: `number`
+Default: `0`
+
+Index of initially-selected item in `items` array.
+
 ### onSelect
 
 Type: `function`

--- a/src/SelectInput.js
+++ b/src/SelectInput.js
@@ -14,6 +14,7 @@ class SelectInput extends PureComponent {
 	static propTypes = {
 		items: PropTypes.array,
 		focus: PropTypes.bool,
+		initialIndex: PropTypes.number,
 		indicatorComponent: PropTypes.func,
 		itemComponent: PropTypes.func,
 		limit: PropTypes.number,
@@ -23,6 +24,7 @@ class SelectInput extends PureComponent {
 	static defaultProps = {
 		items: [],
 		focus: true,
+		initialIndex: 0,
 		indicatorComponent: Indicator,
 		itemComponent: Item,
 		limit: null,
@@ -31,7 +33,7 @@ class SelectInput extends PureComponent {
 
 	state = {
 		rotateIndex: 0,
-		selectedIndex: 0
+		selectedIndex: this.props.initialIndex
 	}
 
 	render() {

--- a/test.js
+++ b/test.js
@@ -68,6 +68,34 @@ test('list', t => {
 	t.is(actual.lastFrame(), expected.lastFrame());
 });
 
+test('list - initial index', t => {
+	const items = [{
+		label: 'First',
+		value: 'first'
+	}, {
+		label: 'Second',
+		value: 'second'
+	}];
+
+	const actual = render(<SelectInput items={items} initialIndex={1}/>);
+
+	const expected = render((
+		<Box flexDirection="column">
+			<Box>
+				<Indicator/>
+				<Item label="First"/>
+			</Box>
+
+			<Box>
+				<Indicator isSelected/>
+				<Item isSelected label="Second"/>
+			</Box>
+		</Box>
+	));
+
+	t.is(actual.lastFrame(), expected.lastFrame());
+});
+
 test('list - custom indicator', t => {
 	const items = [{
 		label: 'Test',


### PR DESCRIPTION
Specifying the initially-selected item allows an app to keep some state about what item is selected, and to restore a select input to that option when returning to it from some other part of the app.