### PR TITLE
Add generics for inferring value type

### DIFF
--- a/src/SelectInput.tsx
+++ b/src/SelectInput.tsx
@@ -14,7 +14,7 @@ interface Props<V> {
 	 * Items to display in a list. Each item must be an object and have `label` and `value` props, it may also optionally have a `key` prop.
 	 * If no `key` prop is provided, `value` will be used as the item key.
 	 */
-	items?: Item<V>[];
+	items?: Array<Item<V>>;
 
 	/**
 	 * Listen to user's input. Useful in case there are multiple input components at the same time and input must be "routed" to a specific component.
@@ -62,6 +62,7 @@ export interface Item<V> {
 	value: V;
 }
 
+// eslint-disable-next-line react/function-component-definition
 function SelectInput<V>({
 	items = [],
 	isFocused = true,
@@ -78,7 +79,7 @@ function SelectInput<V>({
 		typeof customLimit === 'number' && items.length > customLimit;
 	const limit = hasLimit ? Math.min(customLimit!, items.length) : items.length;
 
-	const previousItems = useRef<Item<V>[]>(items);
+	const previousItems = useRef<Array<Item<V>>(items);
 
 	useEffect(() => {
 		if (!isEqual(previousItems.current, items)) {
@@ -173,6 +174,6 @@ function SelectInput<V>({
 			})}
 		</Box>
 	);
-};
+}
 
 export default SelectInput;

--- a/src/SelectInput.tsx
+++ b/src/SelectInput.tsx
@@ -9,12 +9,12 @@ import type {Props as IndicatorProps} from './Indicator';
 import Item from './Item';
 import type {Props as ItemProps} from './Item';
 
-interface Props {
+interface Props<V> {
 	/**
 	 * Items to display in a list. Each item must be an object and have `label` and `value` props, it may also optionally have a `key` prop.
 	 * If no `key` prop is provided, `value` will be used as the item key.
 	 */
-	items?: Item[];
+	items?: Item<V>[];
 
 	/**
 	 * Listen to user's input. Useful in case there are multiple input components at the same time and input must be "routed" to a specific component.
@@ -48,21 +48,21 @@ interface Props {
 	/**
 	 * Function to call when user selects an item. Item object is passed to that function as an argument.
 	 */
-	onSelect?: (item: Item) => void;
+	onSelect?: (item: Item<V>) => void;
 
 	/**
 	 * Function to call when user highlights an item. Item object is passed to that function as an argument.
 	 */
-	onHighlight?: (item: Item) => void;
+	onHighlight?: (item: Item<V>) => void;
 }
 
-export interface Item {
+export interface Item<V> {
 	key?: string;
 	label: string;
-	value: unknown;
+	value: V;
 }
 
-const SelectInput: FC<Props> = ({
+function SelectInput<V>({
 	items = [],
 	isFocused = true,
 	initialIndex = 0,
@@ -71,14 +71,14 @@ const SelectInput: FC<Props> = ({
 	limit: customLimit,
 	onSelect,
 	onHighlight
-}) => {
+}: Props<V>): JSX.Element {
 	const [rotateIndex, setRotateIndex] = useState(0);
 	const [selectedIndex, setSelectedIndex] = useState(initialIndex);
 	const hasLimit =
 		typeof customLimit === 'number' && items.length > customLimit;
 	const limit = hasLimit ? Math.min(customLimit!, items.length) : items.length;
 
-	const previousItems = useRef<Item[]>(items);
+	const previousItems = useRef<Item<V>[]>(items);
 
 	useEffect(() => {
 		if (!isEqual(previousItems.current, items)) {


### PR DESCRIPTION
Hey 👋 ,

I've created this PR to improve TypeScript type checking support. There are not many changes, as you can see, but what it does is very powerful. What the "new" typing system does is it automatically guesses the return type of items. This comes in very handy in `onSelect` callback.

To give you an idea, previously we would have to use the `as` modifier to unwrap `unknown` into concrete type like this

```ts
const data: { id: string, title: string }[] = [];

const View = (
  <Select
    items={data.map((section) => ({
      key: section.id,
      label: section.title,
      value: section,
    }))}
    onSelect={(item) => props.onSelect(item.value as X)} // notice this
  />
);


```

With this PR, we get beautiful intellisense and type-safe onSelect methods

```tsx
const data: { id: string, title: string }[] = [];

const View = (
  <Select
    items={data.map((section) => ({
      key: section.id,
      label: section.title,
      value: section,
    }))}
    onSelect={(item) => props.onSelect(item.value)} // type-checked
  />
);
```

I hope you find this useful! 🙌 