### PR TITLE
Add option to control selected index from outside of the component

### DIFF
--- a/src/SelectInput.tsx
+++ b/src/SelectInput.tsx
@@ -29,6 +29,13 @@ interface Props {
 	 * @default 0
 	 */
 	initialIndex?: number;
+	
+	/**
+	 * Optional controlled index of item in `items` array.
+	 *
+	 * @default 0
+	 */
+	index?: number;
 
 	/**
 	 * Number of items to display.
@@ -66,6 +73,7 @@ const SelectInput: FC<Props> = ({
 	items = [],
 	isFocused = true,
 	initialIndex = 0,
+	index = 0,
 	indicatorComponent = Indicator,
 	itemComponent = Item,
 	limit: customLimit,
@@ -73,7 +81,7 @@ const SelectInput: FC<Props> = ({
 	onHighlight
 }) => {
 	const [rotateIndex, setRotateIndex] = useState(0);
-	const [selectedIndex, setSelectedIndex] = useState(initialIndex);
+	const [selectedIndex, setSelectedIndex] = useState(initialIndex || index);
 	const hasLimit =
 		typeof customLimit === 'number' && items.length > customLimit;
 	const limit = hasLimit ? Math.min(customLimit!, items.length) : items.length;
@@ -88,6 +96,11 @@ const SelectInput: FC<Props> = ({
 
 		previousItems.current = items;
 	}, [items]);
+	
+	useEffect(() => {
+		setRotateIndex(index);
+		setSelectedIndex(index);
+	}, [index]);
 
 	useInput(
 		useCallback(

--- a/src/SelectInput.tsx
+++ b/src/SelectInput.tsx
@@ -58,9 +58,9 @@ interface Props {
 	onSelect?: (item: Item) => void;
 
 	/**
-	 * Function to call when user highlights an item. Item object is passed to that function as an argument.
+	 * Function to call when user highlights an item. Item object is passed to that function as an argument, additionaly its index.
 	 */
-	onHighlight?: (item: Item) => void;
+	onHighlight?: (item: Item, index: number) => void;
 }
 
 export interface Item {
@@ -122,7 +122,7 @@ const SelectInput: FC<Props> = ({
 						: items;
 
 					if (typeof onHighlight === 'function') {
-						onHighlight(slicedItems[nextSelectedIndex]);
+						onHighlight(slicedItems[nextSelectedIndex], nextSelectedIndex);
 					}
 				}
 
@@ -141,7 +141,7 @@ const SelectInput: FC<Props> = ({
 						: items;
 
 					if (typeof onHighlight === 'function') {
-						onHighlight(slicedItems[nextSelectedIndex]);
+						onHighlight(slicedItems[nextSelectedIndex], nextSelectedIndex);
 					}
 				}
 

--- a/src/SelectInput.tsx
+++ b/src/SelectInput.tsx
@@ -98,7 +98,7 @@ const SelectInput: FC<Props> = ({
 	}, [items]);
 	
 	useEffect(() => {
-		if (index) {
+		if (typeof index === 'number') {
 			setRotateIndex(index);
 			setSelectedIndex(index);
 		}

--- a/src/SelectInput.tsx
+++ b/src/SelectInput.tsx
@@ -98,8 +98,10 @@ const SelectInput: FC<Props> = ({
 	}, [items]);
 	
 	useEffect(() => {
-		setRotateIndex(index);
-		setSelectedIndex(index);
+		if (index) {
+			setRotateIndex(index);
+			setSelectedIndex(index);
+		}
 	}, [index]);
 
 	useInput(

--- a/src/SelectInput.tsx
+++ b/src/SelectInput.tsx
@@ -29,11 +29,9 @@ interface Props<V> {
 	 * @default 0
 	 */
 	initialIndex?: number;
-	
+
 	/**
 	 * Optional controlled index of item in `items` array.
-	 *
-	 * @default 0
 	 */
 	index?: number;
 
@@ -74,7 +72,7 @@ function SelectInput<V>({
 	items = [],
 	isFocused = true,
 	initialIndex = 0,
-	index = 0,
+	index,
 	indicatorComponent = Indicator,
 	itemComponent = Item,
 	limit: customLimit,

--- a/src/SelectInput.tsx
+++ b/src/SelectInput.tsx
@@ -81,7 +81,7 @@ const SelectInput: FC<Props> = ({
 	onHighlight
 }) => {
 	const [rotateIndex, setRotateIndex] = useState(0);
-	const [selectedIndex, setSelectedIndex] = useState(initialIndex || index);
+	const [selectedIndex, setSelectedIndex] = useState(typeof index === 'number' ? index : initialIndex);
 	const hasLimit =
 		typeof customLimit === 'number' && items.length > customLimit;
 	const limit = hasLimit ? Math.min(customLimit!, items.length) : items.length;

--- a/test.js
+++ b/test.js
@@ -758,3 +758,32 @@ test('list - onHighlight', async t => {
 	t.deepEqual(onHighlight.firstCall.args[0], items[1]);
 	t.deepEqual(onHighlight.secondCall.args[0], items[2]);
 });
+
+test('list - onHighlight updates index', async t => {
+	const items = [
+		{
+			label: 'First',
+			value: 'first'
+		},
+		{
+			label: 'Second',
+			value: 'second'
+		},
+		{
+			label: 'Third',
+			value: 'third'
+		}
+	];
+
+	const onHighlight = spy();
+	const {stdin} = render(
+		<SelectInput items={items} limit={2} onHighlight={onHighlight}/>
+	);
+
+	await delay(100);
+	stdin.write(ARROW_DOWN);
+
+	t.true(onHighlight.calledOnce);
+	t.deepEqual(onHighlight.firstCall.args[0], items[1]);
+	t.is(onHighlight.firstCall.args[1], 1);
+});

--- a/test.js
+++ b/test.js
@@ -85,18 +85,121 @@ test('list - initial index', t => {
 		}
 	];
 
-	const actual = render(<SelectInput items={items} initialIndex={1} />);
+	const actual = render(<SelectInput items={items} initialIndex={1}/>);
 
 	const expected = render(
 		<Box flexDirection="column">
 			<Box>
-				<Indicator />
-				<Item label="First" />
+				<Indicator/>
+				<Item label="First"/>
 			</Box>
 
 			<Box>
-				<Indicator isSelected />
-				<Item isSelected label="Second" />
+				<Indicator isSelected/>
+				<Item isSelected label="Second"/>
+			</Box>
+		</Box>
+	);
+
+	t.is(actual.lastFrame(), expected.lastFrame());
+});
+
+test('list - controlled index', t => {
+	const items = [
+		{
+			label: 'First',
+			value: 'first'
+		},
+		{
+			label: 'Second',
+			value: 'second'
+		},
+		{
+			label: 'Third',
+			value: 'third'
+		}
+	];
+
+	const actual = render(<SelectInput items={items} index={2}/>);
+
+	const expected = render(
+		<Box flexDirection="column">
+			<Box>
+				<Indicator/>
+				<Item label="First"/>
+			</Box>
+
+			<Box>
+				<Indicator/>
+				<Item label="Second"/>
+			</Box>
+
+			<Box>
+				<Indicator isSelected/>
+				<Item isSelected label="Third"/>
+			</Box>
+		</Box>
+	);
+
+	t.is(actual.lastFrame(), expected.lastFrame());
+
+	actual.rerender(<SelectInput items={items} index={0}/>);
+
+	const newExpected = render(
+		<Box flexDirection="column">
+			<Box>
+				<Indicator isSelected/>
+				<Item isSelected label="First"/>
+			</Box>
+
+			<Box>
+				<Indicator/>
+				<Item label="Second"/>
+			</Box>
+
+			<Box>
+				<Indicator/>
+				<Item label="Third"/>
+			</Box>
+		</Box>
+	);
+
+	t.is(actual.lastFrame(), newExpected.lastFrame());
+});
+
+test('list - controlled index ignores initialIndex', t => {
+	const items = [
+		{
+			label: 'First',
+			value: 'first'
+		},
+		{
+			label: 'Second',
+			value: 'second'
+		},
+		{
+			label: 'Third',
+			value: 'third'
+		}
+	];
+
+	const actual = render(<SelectInput items={items} initialIndex={0} index={2}/>);
+
+	const expected = render(
+		<Box flexDirection="column">
+			<Box>
+				<Indicator/>
+				<Item label="First"/>
+			</Box>
+
+			<Box>
+				<Indicator/>
+				<Item label="Second"/>
+			</Box>
+
+			<Box>
+				<Indicator isSelected/>
+				<Item isSelected label="Third"/>
 			</Box>
 		</Box>
 	);


### PR DESCRIPTION
(creating this as a new pull request for it to count to my [hacktoberfest](https://hacktoberfest.digitalocean.com/profile) contributions)
These changes were made because I wanted to keep the index state in a parent component, so it could listen for user input and a matching option could be highlighted by setting the state. 
When the index prop changes, its value will be used for the selectedIndex, and by passing the nextSelectedIndex to the onHighlight function, that outside state can be kept up-to-date.