### PR TITLE
add named export for default component

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import SelectInput from './SelectInput';
 
 export default SelectInput;
+export {default as SelectInput} from './SelectInput';
 export {default as Indicator, Props as IndicatorProps} from './Indicator';
 export {default as Item, Props as ItemProps} from './Item';


### PR DESCRIPTION
This is a small change, adding a named export for the `TextInput` component, along with (not replacing) the current default export. This is effectively the same as https://github.com/vadimdemedes/ink-text-input/pull/67, but I used the `default as` syntax to better match the following lines.

I am using Ink for a text adventure engine, and have been moving to native ES modules, even for the bundled output. During that effort, https://github.com/ssube/textual-engine/pull/176, I encountered the following error from https://github.com/vadimdemedes/ink-text-input and https://github.com/vadimdemedes/ink-select-input:

```
  9) ink shortcut component
       should update the verb:
     expected '\n  ERROR Element type is invalid: expected a string (for built-in components) or a class/function\n
       (for composite components) but got: object.\n\n
       Check the render method of `Shortcuts`.\n\n - \n - Check the render method of `Shortcuts`.\n -createFiberFromTypeAndPro (node_modules/react-reconciler/cjs/react-reconciler.development.js:1662\n
  10) ink shortcut component
       should handle selections without an item:
     expected '\n  ERROR Element type is invalid: expected a string (for built-in components) or a class/function\n
       (for composite components) but got: object.\n\n
       Check the render method of `Shortcuts`.\n\n - \n - Check the render method of `Shortcuts`.\n -createFiberFromTypeAndPro (node_modules/react-reconciler/cjs/react-reconciler.development.js:1662\n
```

or, when run:

```
node  out/src/index.js --config data/config.yml --data file://data/demo.yml --input 'create a test with test and with 20' --input help
Warning: React.createElement: type is invalid -- expected a string (for built-in components) or a class/function (for composite components) but got: object.

Check the render method of `Input`.
    in Input (created by Frame)
    in ink-box (created by Box)
```

The components from the base Ink library work correctly, as do mine. As far as I can tell, the only difference is the named export vs default export, which makes some sense considering how ES modules are imported (a locally-mutable copy of the exports, afaik):

```
# module
> import('ink-select-input').then((isp) => console.log(typeof isp))
Promise { <pending> }
> object

# default
> import('ink-select-input').then((isp) => console.log(typeof (isp.default)))
Promise {
  <pending>,
  [Symbol(async_id_symbol)]: 70,
  [Symbol(trigger_async_id_symbol)]: 59,
  [Symbol(destroyed)]: { destroyed: false }
}
> object

# named
> import('ink-select-input').then((isp) => console.log(typeof (isp.Item)))
Promise {
  <pending>,
  [Symbol(async_id_symbol)]: 329,
  [Symbol(trigger_async_id_symbol)]: 318,
  [Symbol(destroyed)]: { destroyed: false }
}
> function
```

The error should be reproducible using the `update/major-tests` branch of my project:

```
# for a clean env:
docker run --rm -it --entrypoint bash node:16

# to repro:
git clone --branch update/major-tests https://github.com/ssube/textual-engine.git
cd textual-engine
make cover
```

Adding a named export seems to fix the issue for modules, and should not be a breaking change for other users. Any concerns with making this change?