### PR TITLE
update react peer dependency to allow 17

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
 	},
 	"peerDependencies": {
 		"ink": "^3.0.5",
-		"react": "^16.8.2"
+		"react": "^16.8.2 || ^17.0.0"
 	},
 	"devDependencies": {
 		"@ava/babel": "^1.0.1",
@@ -52,7 +52,7 @@
 		"ink": "^3.0.5",
 		"ink-testing-library": "^2.0.0",
 		"prettier": "^2.0.5",
-		"react": "^16.8.2",
+		"react": "^17.0.0",
 		"sinon": "^7.2.7",
 		"typescript": "^3.9.7",
 		"xo": "^0.32.0"


### PR DESCRIPTION
This fixes peer dependency warnings when working with newer react versions.

(Exactly like this PR https://github.com/vadimdemedes/ink-text-input/pull/70)