### PR TITLE
Color property addition

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -75,6 +75,12 @@ Type: `number`
 
 Number of items to display.
 
+### color
+
+Type: `string`
+
+Custom color when an item is selected.
+
 ### indicatorComponent
 
 Type: `Component`

--- a/src/Indicator.tsx
+++ b/src/Indicator.tsx
@@ -5,6 +5,7 @@ import * as figures from 'figures';
 
 export interface Props {
 	isSelected?: boolean;
+	color?: string;
 }
 
 const Indicator: FC<Props> = ({isSelected = false, color}) => (

--- a/src/Indicator.tsx
+++ b/src/Indicator.tsx
@@ -7,9 +7,9 @@ export interface Props {
 	isSelected?: boolean;
 }
 
-const Indicator: FC<Props> = ({isSelected = false}) => (
+const Indicator: FC<Props> = ({isSelected = false, color}) => (
 	<Box marginRight={1}>
-		{isSelected ? <Text color="blue">{figures.pointer}</Text> : <Text> </Text>}
+		{isSelected ? <Text color={color}>{figures.pointer}</Text> : <Text> </Text>}
 	</Box>
 );
 

--- a/src/Item.tsx
+++ b/src/Item.tsx
@@ -7,8 +7,8 @@ export interface Props {
 	label: string;
 }
 
-const Item: FC<Props> = ({isSelected = false, label}) => (
-	<Text color={isSelected ? 'blue' : undefined}>{label}</Text>
+const Item: FC<Props> = ({isSelected = false, label, color = 'blue'}) => (
+	<Text color={isSelected ? color : undefined}>{label}</Text>
 );
 
 export default Item;

--- a/src/Item.tsx
+++ b/src/Item.tsx
@@ -4,6 +4,7 @@ import {Text} from 'ink';
 
 export interface Props {
 	isSelected?: boolean;
+	color?: string;
 	label: string;
 }
 

--- a/src/SelectInput.tsx
+++ b/src/SelectInput.tsx
@@ -36,6 +36,11 @@ interface Props<V> {
 	limit?: number;
 
 	/**
+	 * Custom color when an item is selected.
+	 */
+	color?: string;
+
+	/**
 	 * Custom component to override the default indicator component.
 	 */
 	indicatorComponent?: FC<IndicatorProps>;

--- a/src/SelectInput.tsx
+++ b/src/SelectInput.tsx
@@ -67,6 +67,7 @@ function SelectInput<V>({
 	items = [],
 	isFocused = true,
 	initialIndex = 0,
+	color = 'blue',
 	indicatorComponent = Indicator,
 	itemComponent = Item,
 	limit: customLimit,
@@ -172,8 +173,8 @@ function SelectInput<V>({
 
 				return (
 					<Box key={item.key ?? item.value}>
-						{React.createElement(indicatorComponent, {isSelected})}
-						{React.createElement(itemComponent, {...item, isSelected})}
+						{React.createElement(indicatorComponent, {isSelected, color})}
+						{React.createElement(itemComponent, {...item, isSelected, color})}
 					</Box>
 				);
 			})}


### PR DESCRIPTION
I find it really useful that you created a way to override the current default components for Indicator and Item entirely, but for my usecase I needed something as simple as changing the default color of the selected text.

### Why

I just wasn't really vibing with 'blue' because of my terminal configs, and I realized there was no option to override this simple text property as it's currently hard coded.

### What it does

My PR just makes it so you can have a color prop in the component to override the default 'blue'.