### PR TITLE
Fix stuck selection when `initialIndex` is larger than `limit`

### DIFF
--- a/src/SelectInput.tsx
+++ b/src/SelectInput.tsx
@@ -73,12 +73,16 @@ function SelectInput<V>({
 	onSelect,
 	onHighlight
 }: Props<V>): JSX.Element {
-	const [rotateIndex, setRotateIndex] = useState(0);
-	const [selectedIndex, setSelectedIndex] = useState(initialIndex);
 	const hasLimit =
 		typeof customLimit === 'number' && items.length > customLimit;
 	const limit = hasLimit ? Math.min(customLimit!, items.length) : items.length;
-
+	const lastIndex = limit - 1;
+	const [rotateIndex, setRotateIndex] = useState(
+		initialIndex > lastIndex ? lastIndex - initialIndex : 0
+	);
+	const [selectedIndex, setSelectedIndex] = useState(
+		initialIndex ? (initialIndex > lastIndex ? lastIndex : initialIndex) : 0
+	);
 	const previousItems = useRef<Array<Item<V>>>(items);
 
 	useEffect(() => {


### PR DESCRIPTION
Fixes #43 

selected index would sometimes be greater than the items array length.  If initialIndex is ever greater than array length we rotate the array and set the index to the max.

Ran prettier.  I appreciate the work on this project.

(I didn't see anything on the contributing.md file on bumping the version so leaving that as is.)