### PR TITLE
refactor: replace `lodash.isequal` with `isDeepStrictEqual` from `node:util`

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,5 @@
 			"unicorn/prevent-abbreviations": "off"
 		}
 	},
-	"prettier": "@vdemedes/prettier-config",
-	"packageManager": "pnpm@10.8.0+sha512.0e82714d1b5b43c74610193cb20734897c1d00de89d0e18420aebc5977fa13d780a9cb05734624e81ebd81cc876cd464794850641c48b9544326b5622ca29971"
+	"prettier": "@vdemedes/prettier-config"
 }

--- a/package.json
+++ b/package.json
@@ -32,12 +32,11 @@
 	],
 	"dependencies": {
 		"figures": "^6.1.0",
-		"lodash.isequal": "^4.5.0",
 		"to-rotated": "^1.0.0"
 	},
 	"devDependencies": {
 		"@sindresorhus/tsconfig": "^5.0.0",
-		"@types/lodash.isequal": "^4.5.8",
+		"@types/node": "^22.14.1",
 		"@types/react": "^18.3.2",
 		"@types/sinon": "^17.0.3",
 		"@vdemedes/prettier-config": "^2.0.1",
@@ -79,5 +78,6 @@
 			"unicorn/prevent-abbreviations": "off"
 		}
 	},
-	"prettier": "@vdemedes/prettier-config"
+	"prettier": "@vdemedes/prettier-config",
+	"packageManager": "pnpm@10.8.0+sha512.0e82714d1b5b43c74610193cb20734897c1d00de89d0e18420aebc5977fa13d780a9cb05734624e81ebd81cc876cd464794850641c48b9544326b5622ca29971"
 }

--- a/src/SelectInput.tsx
+++ b/src/SelectInput.tsx
@@ -1,5 +1,5 @@
+import {isDeepStrictEqual} from 'node:util';
 import React, {type FC, useState, useEffect, useRef, useCallback} from 'react';
-import isEqual from 'lodash.isequal';
 import arrayToRotated from 'to-rotated';
 import {Box, useInput} from 'ink';
 import Indicator, {type Props as IndicatorProps} from './Indicator.js';
@@ -82,7 +82,7 @@ function SelectInput<V>({
 
 	useEffect(() => {
 		if (
-			!isEqual(
+			!isDeepStrictEqual(
 				previousItems.current.map(item => item.value),
 				items.map(item => item.value),
 			)


### PR DESCRIPTION
### Description

This PR replaces the deprecated `lodash.isequal` package with `isDeepStrictEqual` from the `node:util` module to suppress the deprecation warning.

Got the warning message while installing `ink-select-input`:
> npm warn deprecated lodash.isequal@4.5.0: This package is deprecated. Use require('node:util').isDeepStrictEqual instead.

### Changes Made

- Removed `lodash.isequal` from `package.json`.
- Added `@types/node` to `devDependencies`.
- Updated `SelectInput.tsx` to use `isDeepStrictEqual` instead of `lodash.isequal`.

Warning from https://www.npmjs.com/package/lodash.isequal:
> This package is deprecated. Use require('node:util').isDeepStrictEqual instead.
